### PR TITLE
Add function to parse log level from string

### DIFF
--- a/jlo.go
+++ b/jlo.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -61,6 +62,24 @@ var logLevel = InfoLevel
 // SetLogLevel changes the global log level
 func SetLogLevel(level LogLevel) {
 	logLevel = level
+}
+
+// ParseLogLevel parses a log level from a string
+func ParseLogLevel(level string) (LogLevel, error) {
+	switch strings.ToLower(level) {
+	case "fatal":
+		return FatalLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	case "warn", "warning":
+		return WarningLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "debug":
+		return DebugLevel, nil
+	default:
+		return UnknownLevel, fmt.Errorf("invalid log level '%s'", level)
+	}
 }
 
 var Now = func() time.Time {

--- a/jlo_test.go
+++ b/jlo_test.go
@@ -54,6 +54,34 @@ func Test_SetLogLevel(t *testing.T) {
 	}, msg)
 }
 
+func Test_ParseLogLevel(t *testing.T) {
+	tests := map[string]jlo.LogLevel{
+		"fatal":   jlo.FatalLevel,
+		"FATAL":   jlo.FatalLevel,
+		"error":   jlo.ErrorLevel,
+		"ERROR":   jlo.ErrorLevel,
+		"warn":    jlo.WarningLevel,
+		"WARN":    jlo.WarningLevel,
+		"warning": jlo.WarningLevel,
+		"WARNING": jlo.WarningLevel,
+		"info":    jlo.InfoLevel,
+		"INFO":    jlo.InfoLevel,
+		"debug":   jlo.DebugLevel,
+		"DEBUG":   jlo.DebugLevel,
+	}
+
+	for str, level := range tests {
+		parsed, err := jlo.ParseLogLevel(str)
+		require.NoError(t, err)
+		assert.Equal(t, level, parsed)
+	}
+}
+
+func Test_ParseLogLevel_UnknownLevel(t *testing.T) {
+	parsed, err := jlo.ParseLogLevel("unknown")
+	assert.Error(t, err)
+	assert.Equal(t, jlo.UnknownLevel, parsed)
+}
 func Test_Logger_Debugf(t *testing.T) {
 
 	tests := map[string]struct {


### PR DESCRIPTION
This PR adds a function to parse the log level from a string. In optimizer service log package a similar function was added in https://github.com/dcmn-com/dcaud-media-optimizer/pull/48