### PR TITLE
Remove image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Light-weight json logging in go
 
-![ ](https://media.giphy.com/media/l41lI61owQXsxHnvG/giphy.gif)
-
 - Default log level: `INFO`
 - Minimum go version/dependencies: See [go.mod](./go.mod)
 - Release versioning: Semantic versioning/`MAJOR.MINOR.PATCH`


### PR DESCRIPTION
This PR removes the gif image from README to avoid copyright issues, when publishing the project.